### PR TITLE
keyboard: media and system control implementations

### DIFF
--- a/src/hid_report_observer.rs
+++ b/src/hid_report_observer.rs
@@ -1,6 +1,6 @@
 use usb_device::Result;
 
-use crate::hid_settings::{HIDReportId, HIDReport};
+use crate::hid_settings::{HIDReport, HIDReportId};
 
 /// Callback function for sending HID reports.
 pub type SendReportHook = fn(id: HIDReportId, report: HIDReport, result: &Result<()>);
@@ -11,16 +11,21 @@ pub struct HIDReportObserver {
 
 impl HIDReportObserver {
     #[allow(non_upper_case_globals)]
-    const NopSendReportHook: SendReportHook = |_id: HIDReportId, _report: HIDReport, _result: &Result<()>| {};
+    const NopSendReportHook: SendReportHook =
+        |_id: HIDReportId, _report: HIDReport, _result: &Result<()>| {};
 
     /// Creates a new [HIDReportObserver].
     pub const fn new(send_report_hook: SendReportHook) -> Self {
-        Self { send_report_hook: Some(send_report_hook) }
+        Self {
+            send_report_hook: Some(send_report_hook),
+        }
     }
 
     /// Creates a default [HIDReportObserver] with no-op [SendReportHook].
     pub const fn default() -> Self {
-        Self { send_report_hook: Some(Self::NopSendReportHook) }
+        Self {
+            send_report_hook: Some(Self::NopSendReportHook),
+        }
     }
 
     /// Attempts to send an HID report by calling the currently set [SendReportHook].

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -3,8 +3,8 @@ use usbd_hid::descriptor::{KeyboardReport, KeyboardUsage, MediaKey, SystemContro
 use usbd_hid::hid_class::HidCountryCode;
 
 pub mod boot;
-pub mod nkro;
 pub mod media;
+pub mod nkro;
 pub mod system_control;
 
 pub(crate) const ZERO_KEYS: [u8; 6] = [0u8; 6];
@@ -45,7 +45,7 @@ pub(crate) const fn key_to_printable_bitfield(key: u8) -> u8 {
 }
 
 pub(crate) const fn key_to_modifier_bitfield(key: u8) -> u8 {
-   1 << (key - KeyboardUsage::KeyboardLeftControl as u8)
+    1 << (key - KeyboardUsage::KeyboardLeftControl as u8)
 }
 
 // FIXME: allow setting locale at runtime by setting config value in device memory.
@@ -201,7 +201,12 @@ pub trait KeyboardOps {
     /// Gets whether the keycodes have changed between the last and current keyboard report.
     fn keycodes_changed(&self) -> bool {
         let mut changed = 0;
-        for (last, current) in self.last_report().keycodes.iter().zip(self.report().keycodes.iter()) {
+        for (last, current) in self
+            .last_report()
+            .keycodes
+            .iter()
+            .zip(self.report().keycodes.iter())
+        {
             changed |= last ^ current;
         }
         changed != 0
@@ -241,5 +246,4 @@ pub trait KeyboardOps {
     fn leds(&self) -> u8 {
         self.report().leds
     }
-
 }

--- a/src/keyboard/boot.rs
+++ b/src/keyboard/boot.rs
@@ -1,11 +1,13 @@
 use atmega_usbd::UsbBus;
 use avr_device::atmega32u4::USB_DEVICE;
-use usb_device::{Result, class_prelude::UsbBusAllocator};
+use usb_device::{class_prelude::UsbBusAllocator, Result};
 use usbd_hid::descriptor::{KeyboardReport, SerializedDescriptor};
-use usbd_hid::hid_class::{HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig};
+use usbd_hid::hid_class::{
+    HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig,
+};
 
-use crate::hid_settings::{HIDReportId, HIDReport};
 use crate::hid_report_observer::HIDReportObserver;
+use crate::hid_settings::{HIDReport, HIDReportId};
 
 use super::*;
 
@@ -125,7 +127,8 @@ impl KeyboardOps for Keyboard {
             let report = self.report();
             // replace the Ok(usize) with Ok(())
             let ret = hid_class.push_input(report).map(|_| ());
-            self.observer.observe_report(HIDReportId::Keyboard, HIDReport::Keyboard(*report), &ret);
+            self.observer
+                .observe_report(HIDReportId::Keyboard, HIDReport::Keyboard(*report), &ret);
             self.last_report = self.report;
 
             ret

--- a/src/keyboard/media.rs
+++ b/src/keyboard/media.rs
@@ -1,19 +1,16 @@
 use atmega_usbd::UsbBus;
 use avr_device::atmega32u4::USB_DEVICE;
 use usb_device::{Result, class_prelude::UsbBusAllocator};
-use usbd_hid::descriptor::{KeyboardReport, SerializedDescriptor};
+use usbd_hid::descriptor::{MediaKeyboardReport, SerializedDescriptor};
 use usbd_hid::hid_class::{HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig};
-
-use crate::hid_settings::{HIDReportId, HIDReport};
-use crate::hid_report_observer::HIDReportObserver;
 
 use super::*;
 
-const fn hid_class_settings(protocol: HidProtocol) -> HidClassSettings {
+const fn hid_class_settings() -> HidClassSettings {
     HidClassSettings {
-        subclass: HidSubClass::Boot,
-        protocol: protocol,
-        config: ProtocolModeConfig::ForceBoot,
+        subclass: HidSubClass::NoSubClass,
+        protocol: HidProtocol::Keyboard,
+        config: ProtocolModeConfig::DefaultBehavior,
         locale: keyboard_locale(),
     }
 }
@@ -22,10 +19,6 @@ pub struct Keyboard {
     usb_bus: UsbBusAllocator<UsbBus<()>>,
     report: KeyboardReport,
     last_report: KeyboardReport,
-    observer: HIDReportObserver,
-    default_protocol: HidProtocol,
-    protocol: HidProtocol,
-    idle: u8,
 }
 
 impl Keyboard {
@@ -36,52 +29,7 @@ impl Keyboard {
             usb_bus: UsbBus::new(usb),
             report: KeyboardReport::default(),
             last_report: KeyboardReport::default(),
-            observer: HIDReportObserver::default(),
-            default_protocol: HidProtocol::Keyboard,
-            protocol: HidProtocol::Keyboard,
-            idle: 0,
         }
-    }
-
-    /// Creates a new [Keyboard] device, taking ownership of the `USB_DEVICE` register of the
-    /// ATmega32u4.
-    ///
-    /// Allows setting a custom [HIDReportObserver] implementation for firing a callback function
-    /// on HID report events.
-    pub fn new_with_observer(usb: USB_DEVICE, observer: HIDReportObserver) -> Self {
-        Self {
-            usb_bus: UsbBus::new(usb),
-            report: KeyboardReport::default(),
-            last_report: KeyboardReport::default(),
-            observer,
-            default_protocol: HidProtocol::Keyboard,
-            protocol: HidProtocol::Keyboard,
-            idle: 0,
-        }
-    }
-
-    /// Gets the currently set protocol for the boot keyboard.
-    pub fn protocol(&self) -> HidProtocol {
-        self.protocol
-    }
-
-    /// Sets the protocol for the boot keyboard.
-    pub fn set_protocol(&mut self, protocol: HidProtocol) {
-        self.protocol = protocol;
-    }
-
-    /// Gets the default protocol for the boot keyboard.
-    pub fn default_protocol(&self) -> HidProtocol {
-        self.protocol
-    }
-
-    pub fn on_usb_reset(&mut self) {
-        self.protocol = self.default_protocol;
-    }
-
-    /// Gets the idle state of the boot keyboard.
-    pub fn idle(&self) -> u8 {
-        self.idle
     }
 }
 
@@ -117,15 +65,14 @@ impl KeyboardOps for Keyboard {
         if self.keycodes_changed() {
             let hid_class = HIDClass::new_ep_in_with_settings(
                 self.bus(),
-                KeyboardReport::desc(),
+                MediaKeyboardReport::desc(),
                 POLL_MS,
-                hid_class_settings(self.protocol),
+                hid_class_settings(),
             );
 
             let report = self.report();
             // replace the Ok(usize) with Ok(())
             let ret = hid_class.push_input(report).map(|_| ());
-            self.observer.observe_report(HIDReportId::Keyboard, HIDReport::Keyboard(*report), &ret);
             self.last_report = self.report;
 
             ret
@@ -135,12 +82,10 @@ impl KeyboardOps for Keyboard {
     }
 
     fn press(&mut self, key: u8) -> usize {
-        if is_modifier(key) {
-            self.report.modifier |= key_to_modifier_bitfield(key);
-            1
-        } else {
-            let mut done = false;
+        let mut done = false;
+        let is_media_key = is_media(key);
 
+        if is_media_key {
             for keycode in self.report.keycodes.iter_mut() {
                 if *keycode == key {
                     done = true;
@@ -153,15 +98,13 @@ impl KeyboardOps for Keyboard {
                     break;
                 }
             }
-
-            done as usize
         }
+
+        (done && is_media_key) as usize
     }
 
     fn release(&mut self, key: u8) -> usize {
-        if is_modifier(key) {
-            self.report.modifier &= !key_to_modifier_bitfield(key);
-        } else {
+        if is_media(key) {
             // it's some other key:
             // Test the key report to see if the key is present. Clear it if it exists.
             // Check all positions in case the key is present more than once (which it shouldn't be)
@@ -187,7 +130,7 @@ impl KeyboardOps for Keyboard {
             }
         }
 
-        found && is_printable(key)
+        found && is_media(key)
     }
 
     fn was_key_pressed(&self, key: u8) -> bool {
@@ -200,6 +143,6 @@ impl KeyboardOps for Keyboard {
             }
         }
 
-        found && is_printable(key)
+        found && is_media(key)
     }
 }

--- a/src/keyboard/media.rs
+++ b/src/keyboard/media.rs
@@ -1,8 +1,10 @@
 use atmega_usbd::UsbBus;
 use avr_device::atmega32u4::USB_DEVICE;
-use usb_device::{Result, class_prelude::UsbBusAllocator};
+use usb_device::{class_prelude::UsbBusAllocator, Result};
 use usbd_hid::descriptor::{MediaKeyboardReport, SerializedDescriptor};
-use usbd_hid::hid_class::{HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig};
+use usbd_hid::hid_class::{
+    HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig,
+};
 
 use super::*;
 

--- a/src/keyboard/nkro.rs
+++ b/src/keyboard/nkro.rs
@@ -34,7 +34,7 @@ impl Keyboard {
 
     fn send_report_unchecked(&self) -> Result<usize> {
         let hid_class = HIDClass::new_ep_in_with_settings(
-            &self.usb_bus,
+            self.bus(),
             KeyboardReport::desc(),
             POLL_MS,
             hid_class_settings(),
@@ -46,6 +46,8 @@ impl Keyboard {
 }
 
 impl KeyboardOps for Keyboard {
+    type UsbBus = UsbBusAllocator<UsbBus<()>>;
+
     fn report(&self) -> &KeyboardReport {
         &self.report
     }
@@ -60,6 +62,10 @@ impl KeyboardOps for Keyboard {
 
     fn last_report_mut(&mut self) -> &mut KeyboardReport {
         &mut self.last_report
+    }
+
+    fn bus(&self) -> &Self::UsbBus {
+        &self.usb_bus
     }
 
     fn end(&mut self) -> Result<()> {

--- a/src/keyboard/nkro.rs
+++ b/src/keyboard/nkro.rs
@@ -2,7 +2,9 @@ use atmega_usbd::UsbBus;
 use avr_device::atmega32u4::USB_DEVICE;
 use usb_device::{class_prelude::UsbBusAllocator, Result};
 use usbd_hid::descriptor::{KeyboardReport, SerializedDescriptor};
-use usbd_hid::hid_class::{HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig};
+use usbd_hid::hid_class::{
+    HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig,
+};
 
 use super::*;
 
@@ -42,7 +44,6 @@ impl Keyboard {
 
         hid_class.push_input(&self.last_report)
     }
-
 }
 
 impl KeyboardOps for Keyboard {
@@ -115,7 +116,12 @@ impl KeyboardOps for Keyboard {
             // report, and send it to the host.
             let mut non_modifiers_toggled_off = false;
 
-            for (last_key, key) in self.last_report.keycodes.iter_mut().zip(self.report.keycodes.iter()) {
+            for (last_key, key) in self
+                .last_report
+                .keycodes
+                .iter_mut()
+                .zip(self.report.keycodes.iter())
+            {
                 let released_keycodes = *last_key & !key;
                 if released_keycodes != 0 {
                     *last_key &= !released_keycodes;
@@ -132,7 +138,9 @@ impl KeyboardOps for Keyboard {
         }
 
         if self.keycodes_changed() {
-            self.last_report.keycodes.copy_from_slice(self.report.keycodes.as_ref());
+            self.last_report
+                .keycodes
+                .copy_from_slice(self.report.keycodes.as_ref());
             self.send_report_unchecked()?;
         }
 
@@ -140,10 +148,12 @@ impl KeyboardOps for Keyboard {
     }
 
     fn is_key_pressed(&self, key: u8) -> bool {
-        is_printable(key) && self.report.keycodes[key_to_index(key)] & key_to_printable_bitfield(key) != 0
+        is_printable(key)
+            && self.report.keycodes[key_to_index(key)] & key_to_printable_bitfield(key) != 0
     }
 
     fn was_key_pressed(&self, key: u8) -> bool {
-        is_printable(key) && self.last_report.keycodes[key_to_index(key)] & key_to_printable_bitfield(key) != 0
+        is_printable(key)
+            && self.last_report.keycodes[key_to_index(key)] & key_to_printable_bitfield(key) != 0
     }
 }

--- a/src/keyboard/nkro.rs
+++ b/src/keyboard/nkro.rs
@@ -1,6 +1,6 @@
 use atmega_usbd::UsbBus;
 use avr_device::atmega32u4::USB_DEVICE;
-use usb_device::{class_prelude::UsbBusAllocator, Result};
+use usb_device::Result;
 use usbd_hid::descriptor::{KeyboardReport, SerializedDescriptor};
 use usbd_hid::hid_class::{
     HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig,
@@ -18,7 +18,7 @@ const fn hid_class_settings() -> HidClassSettings {
 }
 
 pub struct Keyboard {
-    usb_bus: UsbBusAllocator<UsbBus<()>>,
+    usb_bus: KeyboardUsbBusAllocator,
     report: KeyboardReport,
     last_report: KeyboardReport,
 }
@@ -46,11 +46,27 @@ impl Keyboard {
     }
 }
 
-impl KeyboardOps for Keyboard {
-    type UsbBus = UsbBusAllocator<UsbBus<()>>;
+impl From<KeyboardUsbBusAllocator> for Keyboard {
+    /// Creates a [Keyboard] device from a UsbBusAllocator.
+    ///
+    /// Useful for converting from other keyboard types. Ensures unique ownership over the
+    /// underlying UsbBus.
+    fn from(usb_bus: KeyboardUsbBusAllocator) -> Self {
+        Self {
+            usb_bus,
+            report: KeyboardReport::default(),
+            last_report: KeyboardReport::default(),
+        }
+    }
+}
 
+impl KeyboardOps for Keyboard {
     fn report(&self) -> &KeyboardReport {
         &self.report
+    }
+
+    fn set_report(&mut self, report: KeyboardReport) {
+        self.report = report;
     }
 
     fn report_mut(&mut self) -> &mut KeyboardReport {
@@ -65,7 +81,7 @@ impl KeyboardOps for Keyboard {
         &mut self.last_report
     }
 
-    fn bus(&self) -> &Self::UsbBus {
+    fn bus(&self) -> &KeyboardUsbBusAllocator {
         &self.usb_bus
     }
 
@@ -155,5 +171,9 @@ impl KeyboardOps for Keyboard {
     fn was_key_pressed(&self, key: u8) -> bool {
         is_printable(key)
             && self.last_report.keycodes[key_to_index(key)] & key_to_printable_bitfield(key) != 0
+    }
+
+    fn to_usb_bus(self) -> KeyboardUsbBusAllocator {
+        self.usb_bus
     }
 }

--- a/src/keyboard/system_control.rs
+++ b/src/keyboard/system_control.rs
@@ -1,8 +1,10 @@
 use atmega_usbd::UsbBus;
 use avr_device::atmega32u4::USB_DEVICE;
-use usb_device::{Result, class_prelude::UsbBusAllocator};
-use usbd_hid::descriptor::{SystemControlReport, SerializedDescriptor};
-use usbd_hid::hid_class::{HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig};
+use usb_device::{class_prelude::UsbBusAllocator, Result};
+use usbd_hid::descriptor::{SerializedDescriptor, SystemControlReport};
+use usbd_hid::hid_class::{
+    HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig,
+};
 
 use super::*;
 

--- a/src/keyboard/system_control.rs
+++ b/src/keyboard/system_control.rs
@@ -1,6 +1,6 @@
 use atmega_usbd::UsbBus;
 use avr_device::atmega32u4::USB_DEVICE;
-use usb_device::{class_prelude::UsbBusAllocator, Result};
+use usb_device::Result;
 use usbd_hid::descriptor::{SerializedDescriptor, SystemControlReport};
 use usbd_hid::hid_class::{
     HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig,
@@ -18,7 +18,7 @@ const fn hid_class_settings() -> HidClassSettings {
 }
 
 pub struct Keyboard {
-    usb_bus: UsbBusAllocator<UsbBus<()>>,
+    usb_bus: KeyboardUsbBusAllocator,
     report: KeyboardReport,
     last_report: KeyboardReport,
 }
@@ -35,11 +35,27 @@ impl Keyboard {
     }
 }
 
-impl KeyboardOps for Keyboard {
-    type UsbBus = UsbBusAllocator<UsbBus<()>>;
+impl From<KeyboardUsbBusAllocator> for Keyboard {
+    /// Creates a [Keyboard] device from a UsbBusAllocator.
+    ///
+    /// Useful for converting from other keyboard types. Ensures unique ownership over the
+    /// underlying UsbBus.
+    fn from(usb_bus: KeyboardUsbBusAllocator) -> Self {
+        Self {
+            usb_bus,
+            report: KeyboardReport::default(),
+            last_report: KeyboardReport::default(),
+        }
+    }
+}
 
+impl KeyboardOps for Keyboard {
     fn report(&self) -> &KeyboardReport {
         &self.report
+    }
+
+    fn set_report(&mut self, report: KeyboardReport) {
+        self.report = report;
     }
 
     fn report_mut(&mut self) -> &mut KeyboardReport {
@@ -54,7 +70,7 @@ impl KeyboardOps for Keyboard {
         &mut self.last_report
     }
 
-    fn bus(&self) -> &Self::UsbBus {
+    fn bus(&self) -> &KeyboardUsbBusAllocator {
         &self.usb_bus
     }
 
@@ -146,5 +162,9 @@ impl KeyboardOps for Keyboard {
         }
 
         found && is_system_control(key)
+    }
+
+    fn to_usb_bus(self) -> KeyboardUsbBusAllocator {
+        self.usb_bus
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,8 @@ mod keyboard;
 pub use hid_report_observer::*;
 pub use hid_settings::*;
 pub use keyboard::*;
+
+/// Re-export of the [usb-device](https://docs.rs/usb-device/latest/usb_device/) library.
+pub use usb_device;
+/// Re-export of the [usbd-hid](https://docs.rs/usbd-hid/latest/usbd_hid) library.
+pub use usbd_hid;


### PR DESCRIPTION
Adds `media::Keyboard` and `system_control::Keyboard` implementations to send the corresponding keyboard reports.