### PR TITLE
traits: refactor traits for HID class-specific behavior

### DIFF
--- a/src/keyboard/media.rs
+++ b/src/keyboard/media.rs
@@ -1,5 +1,3 @@
-use atmega_usbd::UsbBus;
-use avr_device::atmega32u4::USB_DEVICE;
 use usb_device::Result;
 use usbd_hid::descriptor::{MediaKeyboardReport, SerializedDescriptor};
 use usbd_hid::hid_class::{
@@ -8,7 +6,7 @@ use usbd_hid::hid_class::{
 
 use super::*;
 
-const fn hid_class_settings() -> HidClassSettings {
+const fn media_hid_class_settings() -> HidClassSettings {
     HidClassSettings {
         subclass: HidSubClass::NoSubClass,
         protocol: HidProtocol::Keyboard,
@@ -17,63 +15,56 @@ const fn hid_class_settings() -> HidClassSettings {
     }
 }
 
-pub struct Keyboard {
-    usb_bus: KeyboardUsbBusAllocator,
-    report: KeyboardReport,
-    last_report: KeyboardReport,
-}
+pub trait MediaKeyboard {
+    /// End the keyboard reports.
+    fn end(&mut self) -> Result<()>;
 
-impl Keyboard {
-    /// Creates a new [Keyboard] device, taking ownership of the `USB_DEVICE` register of the
-    /// ATmega32u4
-    pub fn new(usb: USB_DEVICE) -> Self {
-        Self {
-            usb_bus: UsbBus::new(usb),
-            report: KeyboardReport::default(),
-            last_report: KeyboardReport::default(),
-        }
-    }
-}
-
-impl From<KeyboardUsbBusAllocator> for Keyboard {
-    /// Creates a [Keyboard] device from a UsbBusAllocator.
+    /// Sending the current HID report to the host:
     ///
-    /// Useful for converting from other keyboard types. Ensures unique ownership over the
-    /// underlying UsbBus.
-    fn from(usb_bus: KeyboardUsbBusAllocator) -> Self {
-        Self {
-            usb_bus,
-            report: KeyboardReport::default(),
-            last_report: KeyboardReport::default(),
-        }
-    }
+    /// Depending on the differences between the current and previous HID reports, we
+    /// might need to send one or two extra reports to guarantee that the host will
+    /// process the changes in the correct order. There are two important scenarios
+    /// to consider:
+    ///
+    /// 1. If a non-modifier keycode toggles off in the same report as a modifier
+    /// changes, the host might process the modifier change first. For example, if
+    /// both `shift` and `4` toggle off in the same report (most likely from a
+    /// `LSHIFT(Key_4)` key being released), and that key has been held long enough
+    /// to trigger character repeat, we could end up with a plain `4` in the output
+    /// at the end of the repeat: `$$$$4` instead of `$$$$$`.
+    ///
+    /// 2. If a non-modifier keycode toggles on in the same report as a modifier
+    /// changes, the host might process the non-modifer first. For example, pressing
+    /// and holding an `LSHIFT(Key_4)` key might result in `4$$$` rather than `$$$$`.
+    ///
+    /// Therefore, each call to `sendReport()` must send (up to) three reports to the
+    /// host to guarantee the correct order of processing:
+    ///
+    /// 1. A report with toggled-off non-modifiers removed.
+    /// 2. A report with changes to modifiers.
+    /// 3. A report with toggled-on non-modifiers added.
+    fn send_report(&mut self) -> Result<()>;
+
+    /// Press a key, and add it to the current report.
+    ///
+    /// Returns 1 if the key is in the printable keycodes, or is a modifier key.
+    /// Returns 0 otherwise.
+    fn press(&mut self, key: u8) -> usize;
+
+    /// Release a pressed key if the keycode is present in the current report.
+    ///
+    /// Returns 1 if the key is in the printable keycodes, or is a modifier key.
+    /// Returns 0 otherwise.
+    fn release(&mut self, key: u8) -> usize;
+
+    /// Gets whether the provided key is pressed in the current keyboard report.
+    fn is_key_pressed(&self, key: u8) -> bool;
+
+    /// Gets whether the provided key was pressed in the previous keyboard report.
+    fn was_key_pressed(&self, key: u8) -> bool;
 }
 
-impl KeyboardOps for Keyboard {
-    fn report(&self) -> &KeyboardReport {
-        &self.report
-    }
-
-    fn set_report(&mut self, report: KeyboardReport) {
-        self.report = report;
-    }
-
-    fn report_mut(&mut self) -> &mut KeyboardReport {
-        &mut self.report
-    }
-
-    fn last_report(&self) -> &KeyboardReport {
-        &self.last_report
-    }
-
-    fn last_report_mut(&mut self) -> &mut KeyboardReport {
-        &mut self.last_report
-    }
-
-    fn bus(&self) -> &KeyboardUsbBusAllocator {
-        &self.usb_bus
-    }
-
+impl MediaKeyboard for Keyboard {
     fn end(&mut self) -> Result<()> {
         self.release_all();
         self.send_report()
@@ -85,7 +76,7 @@ impl KeyboardOps for Keyboard {
                 self.bus(),
                 MediaKeyboardReport::desc(),
                 POLL_MS,
-                hid_class_settings(),
+                media_hid_class_settings(),
             );
 
             let report = self.report();
@@ -162,9 +153,5 @@ impl KeyboardOps for Keyboard {
         }
 
         found && is_media(key)
-    }
-
-    fn to_usb_bus(self) -> KeyboardUsbBusAllocator {
-        self.usb_bus
     }
 }

--- a/src/keyboard/nkro.rs
+++ b/src/keyboard/nkro.rs
@@ -1,5 +1,3 @@
-use atmega_usbd::UsbBus;
-use avr_device::atmega32u4::USB_DEVICE;
 use usb_device::Result;
 use usbd_hid::descriptor::{KeyboardReport, SerializedDescriptor};
 use usbd_hid::hid_class::{
@@ -8,7 +6,7 @@ use usbd_hid::hid_class::{
 
 use super::*;
 
-const fn hid_class_settings() -> HidClassSettings {
+const fn nkro_hid_class_settings() -> HidClassSettings {
     HidClassSettings {
         subclass: HidSubClass::NoSubClass,
         protocol: HidProtocol::Keyboard,
@@ -17,74 +15,59 @@ const fn hid_class_settings() -> HidClassSettings {
     }
 }
 
-pub struct Keyboard {
-    usb_bus: KeyboardUsbBusAllocator,
-    report: KeyboardReport,
-    last_report: KeyboardReport,
-}
+pub trait NKROKeyboard {
+    /// End the keyboard reports.
+    fn end(&mut self) -> Result<()>;
 
-impl Keyboard {
-    /// Creates a new [Keyboard] device, taking ownership of the `USB_DEVICE` register of the
-    /// ATmega32u4.
-    pub fn new(usb: USB_DEVICE) -> Self {
-        Self {
-            usb_bus: UsbBus::new(usb),
-            report: KeyboardReport::default(),
-            last_report: KeyboardReport::default(),
-        }
-    }
-
-    fn send_report_unchecked(&self) -> Result<usize> {
-        let hid_class = HIDClass::new_ep_in_with_settings(
-            self.bus(),
-            KeyboardReport::desc(),
-            POLL_MS,
-            hid_class_settings(),
-        );
-
-        hid_class.push_input(&self.last_report)
-    }
-}
-
-impl From<KeyboardUsbBusAllocator> for Keyboard {
-    /// Creates a [Keyboard] device from a UsbBusAllocator.
+    /// Press a key, and add it to the current report.
     ///
-    /// Useful for converting from other keyboard types. Ensures unique ownership over the
-    /// underlying UsbBus.
-    fn from(usb_bus: KeyboardUsbBusAllocator) -> Self {
-        Self {
-            usb_bus,
-            report: KeyboardReport::default(),
-            last_report: KeyboardReport::default(),
-        }
-    }
+    /// Returns 1 if the key is in the printable keycodes, or is a modifier key.
+    /// Returns 0 otherwise.
+    fn press(&mut self, key: u8) -> usize;
+
+    /// Release a pressed key if the keycode is present in the current report.
+    ///
+    /// Returns 1 if the key is in the printable keycodes, or is a modifier key.
+    /// Returns 0 otherwise.
+    fn release(&mut self, key: u8) -> usize;
+
+    /// Sending the current HID report to the host:
+    ///
+    /// Depending on the differences between the current and previous HID reports, we
+    /// might need to send one or two extra reports to guarantee that the host will
+    /// process the changes in the correct order. There are two important scenarios
+    /// to consider:
+    ///
+    /// 1. If a non-modifier keycode toggles off in the same report as a modifier
+    /// changes, the host might process the modifier change first. For example, if
+    /// both `shift` and `4` toggle off in the same report (most likely from a
+    /// `LSHIFT(Key_4)` key being released), and that key has been held long enough
+    /// to trigger character repeat, we could end up with a plain `4` in the output
+    /// at the end of the repeat: `$$$$4` instead of `$$$$$`.
+    ///
+    /// 2. If a non-modifier keycode toggles on in the same report as a modifier
+    /// changes, the host might process the non-modifer first. For example, pressing
+    /// and holding an `LSHIFT(Key_4)` key might result in `4$$$` rather than `$$$$`.
+    ///
+    /// Therefore, each call to `sendReport()` must send (up to) three reports to the
+    /// host to guarantee the correct order of processing:
+    ///
+    /// 1. A report with toggled-off non-modifiers removed.
+    /// 2. A report with changes to modifiers.
+    /// 3. A report with toggled-on non-modifiers added.
+    fn send_report(&mut self) -> Result<()>;
+
+    /// Sends a keyboard report without check report validity.
+    fn send_report_unchecked(&self) -> Result<usize>;
+
+    /// Gets whether the provided key is pressed in the current keyboard report.
+    fn is_key_pressed(&self, key: u8) -> bool;
+
+    /// Gets whether the provided key was pressed in the previous keyboard report.
+    fn was_key_pressed(&self, key: u8) -> bool;
 }
 
-impl KeyboardOps for Keyboard {
-    fn report(&self) -> &KeyboardReport {
-        &self.report
-    }
-
-    fn set_report(&mut self, report: KeyboardReport) {
-        self.report = report;
-    }
-
-    fn report_mut(&mut self) -> &mut KeyboardReport {
-        &mut self.report
-    }
-
-    fn last_report(&self) -> &KeyboardReport {
-        &self.last_report
-    }
-
-    fn last_report_mut(&mut self) -> &mut KeyboardReport {
-        &mut self.last_report
-    }
-
-    fn bus(&self) -> &KeyboardUsbBusAllocator {
-        &self.usb_bus
-    }
-
+impl NKROKeyboard for Keyboard {
     fn end(&mut self) -> Result<()> {
         self.release_all();
         self.send_report_unchecked()?;
@@ -163,6 +146,18 @@ impl KeyboardOps for Keyboard {
         Ok(())
     }
 
+    fn send_report_unchecked(&self) -> Result<usize> {
+        let hid_class = HIDClass::new_ep_in_with_settings(
+            self.bus(),
+            KeyboardReport::desc(),
+            POLL_MS,
+            nkro_hid_class_settings(),
+        );
+
+        hid_class.push_input(&self.last_report)
+    }
+
+
     fn is_key_pressed(&self, key: u8) -> bool {
         is_printable(key)
             && self.report.keycodes[key_to_index(key)] & key_to_printable_bitfield(key) != 0
@@ -171,9 +166,5 @@ impl KeyboardOps for Keyboard {
     fn was_key_pressed(&self, key: u8) -> bool {
         is_printable(key)
             && self.last_report.keycodes[key_to_index(key)] & key_to_printable_bitfield(key) != 0
-    }
-
-    fn to_usb_bus(self) -> KeyboardUsbBusAllocator {
-        self.usb_bus
     }
 }

--- a/src/keyboard/system_control.rs
+++ b/src/keyboard/system_control.rs
@@ -1,5 +1,3 @@
-use atmega_usbd::UsbBus;
-use avr_device::atmega32u4::USB_DEVICE;
 use usb_device::Result;
 use usbd_hid::descriptor::{SerializedDescriptor, SystemControlReport};
 use usbd_hid::hid_class::{
@@ -8,7 +6,7 @@ use usbd_hid::hid_class::{
 
 use super::*;
 
-const fn hid_class_settings() -> HidClassSettings {
+const fn system_control_hid_class_settings() -> HidClassSettings {
     HidClassSettings {
         subclass: HidSubClass::NoSubClass,
         protocol: HidProtocol::Keyboard,
@@ -17,63 +15,56 @@ const fn hid_class_settings() -> HidClassSettings {
     }
 }
 
-pub struct Keyboard {
-    usb_bus: KeyboardUsbBusAllocator,
-    report: KeyboardReport,
-    last_report: KeyboardReport,
-}
+pub trait SystemControlKeyboard {
+    /// End the keyboard reports.
+    fn end(&mut self) -> Result<()>;
 
-impl Keyboard {
-    /// Creates a new [Keyboard] device, taking ownership of the `USB_DEVICE` register of the
-    /// ATmega32u4
-    pub fn new(usb: USB_DEVICE) -> Self {
-        Self {
-            usb_bus: UsbBus::new(usb),
-            report: KeyboardReport::default(),
-            last_report: KeyboardReport::default(),
-        }
-    }
-}
-
-impl From<KeyboardUsbBusAllocator> for Keyboard {
-    /// Creates a [Keyboard] device from a UsbBusAllocator.
+    /// Sending the current HID report to the host:
     ///
-    /// Useful for converting from other keyboard types. Ensures unique ownership over the
-    /// underlying UsbBus.
-    fn from(usb_bus: KeyboardUsbBusAllocator) -> Self {
-        Self {
-            usb_bus,
-            report: KeyboardReport::default(),
-            last_report: KeyboardReport::default(),
-        }
-    }
+    /// Depending on the differences between the current and previous HID reports, we
+    /// might need to send one or two extra reports to guarantee that the host will
+    /// process the changes in the correct order. There are two important scenarios
+    /// to consider:
+    ///
+    /// 1. If a non-modifier keycode toggles off in the same report as a modifier
+    /// changes, the host might process the modifier change first. For example, if
+    /// both `shift` and `4` toggle off in the same report (most likely from a
+    /// `LSHIFT(Key_4)` key being released), and that key has been held long enough
+    /// to trigger character repeat, we could end up with a plain `4` in the output
+    /// at the end of the repeat: `$$$$4` instead of `$$$$$`.
+    ///
+    /// 2. If a non-modifier keycode toggles on in the same report as a modifier
+    /// changes, the host might process the non-modifer first. For example, pressing
+    /// and holding an `LSHIFT(Key_4)` key might result in `4$$$` rather than `$$$$`.
+    ///
+    /// Therefore, each call to `sendReport()` must send (up to) three reports to the
+    /// host to guarantee the correct order of processing:
+    ///
+    /// 1. A report with toggled-off non-modifiers removed.
+    /// 2. A report with changes to modifiers.
+    /// 3. A report with toggled-on non-modifiers added.
+    fn send_report(&mut self) -> Result<()>;
+
+    /// Press a key, and add it to the current report.
+    ///
+    /// Returns 1 if the key is in the printable keycodes, or is a modifier key.
+    /// Returns 0 otherwise.
+    fn press(&mut self, key: u8) -> usize;
+
+    /// Release a pressed key if the keycode is present in the current report.
+    ///
+    /// Returns 1 if the key is in the printable keycodes, or is a modifier key.
+    /// Returns 0 otherwise.
+    fn release(&mut self, key: u8) -> usize;
+
+    /// Gets whether the provided key is pressed in the current keyboard report.
+    fn is_key_pressed(&self, key: u8) -> bool;
+
+    /// Gets whether the provided key was pressed in the previous keyboard report.
+    fn was_key_pressed(&self, key: u8) -> bool;
 }
 
-impl KeyboardOps for Keyboard {
-    fn report(&self) -> &KeyboardReport {
-        &self.report
-    }
-
-    fn set_report(&mut self, report: KeyboardReport) {
-        self.report = report;
-    }
-
-    fn report_mut(&mut self) -> &mut KeyboardReport {
-        &mut self.report
-    }
-
-    fn last_report(&self) -> &KeyboardReport {
-        &self.last_report
-    }
-
-    fn last_report_mut(&mut self) -> &mut KeyboardReport {
-        &mut self.last_report
-    }
-
-    fn bus(&self) -> &KeyboardUsbBusAllocator {
-        &self.usb_bus
-    }
-
+impl SystemControlKeyboard for Keyboard {
     fn end(&mut self) -> Result<()> {
         self.release_all();
         self.send_report()
@@ -85,7 +76,7 @@ impl KeyboardOps for Keyboard {
                 self.bus(),
                 SystemControlReport::desc(),
                 POLL_MS,
-                hid_class_settings(),
+                system_control_hid_class_settings(),
             );
 
             let report = self.report();
@@ -162,9 +153,5 @@ impl KeyboardOps for Keyboard {
         }
 
         found && is_system_control(key)
-    }
-
-    fn to_usb_bus(self) -> KeyboardUsbBusAllocator {
-        self.usb_bus
     }
 }


### PR DESCRIPTION
Changes to using traits for HID class-specific behavior, instead of structs that implement a single generic `KeyboardOps` trait. This allows for a single concrete implementation for storing all state information, while still being able to call class-specific functionality.