### PR TITLE
keyboard: add trait functions to get a new HID class

### DIFF
--- a/src/keyboard/media.rs
+++ b/src/keyboard/media.rs
@@ -45,6 +45,8 @@ pub trait MediaKeyboard {
     /// 3. A report with toggled-on non-modifiers added.
     fn send_report(&mut self) -> Result<()>;
 
+    fn hid_class(&self) -> HIDClass<'_, KeyboardUsbBus>;
+
     /// Press a key, and add it to the current report.
     ///
     /// Returns 1 if the key is in the printable keycodes, or is a modifier key.
@@ -72,22 +74,24 @@ impl MediaKeyboard for Keyboard {
 
     fn send_report(&mut self) -> Result<()> {
         if self.keycodes_changed() {
-            let hid_class = HIDClass::new_ep_in_with_settings(
-                self.bus(),
-                MediaKeyboardReport::desc(),
-                POLL_MS,
-                media_hid_class_settings(),
-            );
-
             let report = self.report();
             // replace the Ok(usize) with Ok(())
-            let ret = hid_class.push_input(report).map(|_| ());
+            let ret = self.hid_class().push_input(report).map(|_| ());
             self.last_report = self.report;
 
             ret
         } else {
             Ok(())
         }
+    }
+
+    fn hid_class(&self) -> HIDClass<'_, KeyboardUsbBus> {
+        HIDClass::new_with_settings(
+            self.bus(),
+            MediaKeyboardReport::desc(),
+            POLL_MS,
+            media_hid_class_settings(),
+        )
     }
 
     fn press(&mut self, key: u8) -> usize {

--- a/src/keyboard/nkro.rs
+++ b/src/keyboard/nkro.rs
@@ -60,6 +60,8 @@ pub trait NKROKeyboard {
     /// Sends a keyboard report without check report validity.
     fn send_report_unchecked(&self) -> Result<usize>;
 
+    fn hid_class(&self) -> HIDClass<'_, KeyboardUsbBus>;
+
     /// Gets whether the provided key is pressed in the current keyboard report.
     fn is_key_pressed(&self, key: u8) -> bool;
 
@@ -147,16 +149,17 @@ impl NKROKeyboard for Keyboard {
     }
 
     fn send_report_unchecked(&self) -> Result<usize> {
-        let hid_class = HIDClass::new_ep_in_with_settings(
+        self.hid_class().push_input(&self.last_report)
+    }
+
+    fn hid_class(&self) -> HIDClass<'_, KeyboardUsbBus> {
+        HIDClass::new_with_settings(
             self.bus(),
             KeyboardReport::desc(),
             POLL_MS,
             nkro_hid_class_settings(),
-        );
-
-        hid_class.push_input(&self.last_report)
+        )
     }
-
 
     fn is_key_pressed(&self, key: u8) -> bool {
         is_printable(key)


### PR DESCRIPTION
Supports creating a new HID class for the different keyboard class subtypes.

Future work may make the HID class a structure member instead, to maintain state set by the host. TBD