### PR TITLE
keyboard: add persistent HIDClass member

### DIFF
--- a/src/keyboard/media.rs
+++ b/src/keyboard/media.rs
@@ -1,12 +1,11 @@
 use usb_device::Result;
-use usbd_hid::descriptor::{MediaKeyboardReport, SerializedDescriptor};
 use usbd_hid::hid_class::{
-    HIDClass, HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig,
+    HidClassSettings, HidProtocol, HidSubClass, ProtocolModeConfig,
 };
 
 use super::*;
 
-const fn media_hid_class_settings() -> HidClassSettings {
+pub const fn media_hid_class_settings() -> HidClassSettings {
     HidClassSettings {
         subclass: HidSubClass::NoSubClass,
         protocol: HidProtocol::Keyboard,
@@ -45,8 +44,6 @@ pub trait MediaKeyboard {
     /// 3. A report with toggled-on non-modifiers added.
     fn send_report(&mut self) -> Result<()>;
 
-    fn hid_class(&self) -> HIDClass<'_, KeyboardUsbBus>;
-
     /// Press a key, and add it to the current report.
     ///
     /// Returns 1 if the key is in the printable keycodes, or is a modifier key.
@@ -66,7 +63,7 @@ pub trait MediaKeyboard {
     fn was_key_pressed(&self, key: u8) -> bool;
 }
 
-impl MediaKeyboard for Keyboard {
+impl MediaKeyboard for Keyboard<'_> {
     fn end(&mut self) -> Result<()> {
         self.release_all();
         self.send_report()
@@ -74,24 +71,15 @@ impl MediaKeyboard for Keyboard {
 
     fn send_report(&mut self) -> Result<()> {
         if self.keycodes_changed() {
-            let report = self.report();
+            let report = self.report().clone();
             // replace the Ok(usize) with Ok(())
-            let ret = self.hid_class().push_input(report).map(|_| ());
+            let ret = self.hid_class_mut().push_input(&report).map(|_| ());
             self.last_report = self.report;
 
             ret
         } else {
             Ok(())
         }
-    }
-
-    fn hid_class(&self) -> HIDClass<'_, KeyboardUsbBus> {
-        HIDClass::new_with_settings(
-            self.bus(),
-            MediaKeyboardReport::desc(),
-            POLL_MS,
-            media_hid_class_settings(),
-        )
     }
 
     fn press(&mut self, key: u8) -> usize {


### PR DESCRIPTION
Adds persistent HIDClass member to `Keyboard` struct. Configures HIDClass settings based on the type of keyboard desired.